### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        'torch',
-        'torchvision',
-        'scikit-image',
-        'tqdm',
-        'numpy',
-        'pandas'
+        'torch>=1',
+        'torchvision>=0.5',
+        'scikit-image>=0.16',
+        'tqdm>=4',
+        'numpy>=1',
+        'pandas>=1'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,12 @@ setuptools.setup(
         "Topic :: Scientific/Engineering :: Medical Science Apps."
     ],
     python_requires='>=3.6',
+    install_requires=[
+        'torch',
+        'torchvision',
+        'scikit-image',
+        'tqdm',
+        'numpy',
+        'pandas'
+    ],
 )


### PR DESCRIPTION
Currently, when pip installing the package, dependencies must manually be installed. This pull request adds required packages to `setup.py` such that installing the package via pip also installs dependencies.