### PR TITLE
Minors in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note: Each pretrained model has 18 outputs. The `all` model has every output tra
 
 ```python3
 model = xrv.models.DenseNet(weights="all")
-model = xrv.models.DenseNet(weights="kaggle") # RSNA Pneumonia Challenge
+model = xrv.models.DenseNet(weights="rsna") # RSNA Pneumonia Challenge
 model = xrv.models.DenseNet(weights="nih") # NIH chest X-ray8
 model = xrv.models.DenseNet(weights="pc") # PadChest (University of Alicante)
 model = xrv.models.DenseNet(weights="chex") # CheXpert (Stanford)


### PR DESCRIPTION
To load the model the right command is 
`model = xrv.models.DenseNet(weights="rsna") # RSNA Pneumonia Challenge`
instead of
`model = xrv.models.DenseNet(weights="kaggle") # RSNA Pneumonia Challenge`
as suggested in the current readme.md