### PR TITLE
missing self. in weights_filename_local

### DIFF
--- a/torchxrayvision/models.py
+++ b/torchxrayvision/models.py
@@ -215,7 +215,7 @@ class DenseNet(nn.Module):
 
                 self.load_state_dict(savedmodel.state_dict())
             except Exception as e:
-                print("Loading failure. Check weights file:", weights_filename_local)
+                print("Loading failure. Check weights file:", self.weights_filename_local)
                 raise e
             
             self.eval()


### PR DESCRIPTION
line 218 when the weight is somehow not loaded correctly
we get an error on weights_filename_local is not defined instead of the real error
which is because it should be self.weights_filename_local instead of weights_filename_local