### PR TITLE
Fix autoencoder variable assignment to address gradient error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       max-parallel: 2
       matrix:
         python-version: [3.6,3.8]
-        torch-version: [1.7.1,1.8.1,1.9,1.10]
+        torch-version: [1.7.1,1.8.1,1.9,1.10.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       max-parallel: 2
       matrix:
         python-version: [3.6,3.8]
-        torch-version: [1.7.1,1.8.1,1.9]
+        torch-version: [1.7.1,1.8.1,1.9,1.10]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/torchxrayvision/autoencoders.py
+++ b/torchxrayvision/autoencoders.py
@@ -52,7 +52,7 @@ class Bottleneck(nn.Module):
         if self.downsample is not None:
             shortcut = self.downsample(x)
 
-        out += shortcut
+        out = out + shortcut
         out = self.relu(out)
 
         return out
@@ -99,7 +99,7 @@ class DeconvBottleneck(nn.Module):
         if self.upsample is not None:
             shortcut = self.upsample(x)
 
-        out += shortcut
+        out = out + shortcut
         out = self.relu(out)
 
         return out


### PR DESCRIPTION
To address the following error:
```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [1, 64, 224, 224]], which is output 0 of ReluBackward0, is at version 1; expected version 0 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```