### PR TITLE
raise errors on incorrect usage

### DIFF
--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -122,3 +122,54 @@ def test_dataloader_merging_incorrect_alignment():
         dd = xrv.datasets.Merge_Dataset([d_nih, d_pc])
 
     assert "incorrect pathology alignment" in str(excinfo.value)
+    
+    
+    
+    
+def test_errors_when_doing_things_that_shouldnt_work():
+    
+    
+    transform = torchvision.transforms.Compose([xrv.datasets.XRayCenterCrop(),
+                                                xrv.datasets.XRayResizer(224)])
+    
+    data_aug = torchvision.transforms.Compose([
+        xrv.datasets.ToPILImage(),
+        torchvision.transforms.RandomAffine(15, translate=(0.1, 0.1), scale=(0.5, 1.5)),
+        torchvision.transforms.ToTensor()
+    ])
+    
+    datasets = []
+    for dataset_class in dataset_classes:
+        dataset = dataset_class(imgpath=".", transform=transform, data_aug=data_aug)
+        datasets.append(dataset)
+
+    for dataset in datasets:
+        xrv.datasets.relabel_dataset(xrv.datasets.default_pathologies, dataset)
+
+    merged_dataset = xrv.datasets.MergeDataset(datasets)
+    
+    with pytest.raises(NotImplementedError) as excinfo:
+        # Try to set the transforms on a merged dataset
+        merged_dataset.transform = None
+        
+    with pytest.raises(NotImplementedError) as excinfo:
+        # Try to set the data_aug on a merged dataset
+        merged_dataset.transform = None
+    
+    
+    subset_dataset = xrv.datasets.SubsetDataset(datasets[0], [0,1,2])
+    
+    with pytest.raises(NotImplementedError) as excinfo:
+        # Try to set the transforms on a subset dataset
+        subset_dataset.transform = None
+        
+    with pytest.raises(NotImplementedError) as excinfo:
+        # Try to set the data_aug on a subset dataset
+        subset_dataset.transform = None
+    
+    
+    
+    
+    
+    
+    

--- a/torchxrayvision/datasets.py
+++ b/torchxrayvision/datasets.py
@@ -168,6 +168,15 @@ class MergeDataset(Dataset):
 
         self.csv = self.csv.reset_index(drop=True)
 
+    def __setattr__(self, name, value):
+        if name == "transform":
+            raise NotImplementedError("Cannot set transform on a merged dataset. Set the transforms directly on the dataset object. If it was to be set via this merged dataset if would have to modify the internal datasets which could have unexpected side effects")
+        if name == "data_aug":
+            raise NotImplementedError("Cannot set data_aug on a merged dataset. Set the transforms directly on the dataset object. If it was to be set via this merged dataset if would have to modify the internal datasets which could have unexpected side effects")
+            
+        object.__setattr__(self, name, value)
+        
+    
     def string(self):
         s = self.__class__.__name__ + " num_samples={}\n".format(len(self))
         for i, d in enumerate(self.datasets):
@@ -231,6 +240,14 @@ class SubsetDataset(Dataset):
         if hasattr(self.dataset, 'which_dataset'):
             self.which_dataset = self.dataset.which_dataset[self.idxs]
 
+    def __setattr__(self, name, value):
+        if name == "transform":
+            raise NotImplementedError("Cannot set transform on a subset dataset. Set the transforms directly on the dataset object. If it was to be set via this subset dataset if would have to modify the internal dataset which could have unexpected side effects")
+        if name == "data_aug":
+            raise NotImplementedError("Cannot set data_aug on a subset dataset. Set the transforms directly on the dataset object. If it was to be set via this subset dataset if would have to modify the internal dataset which could have unexpected side effects")
+            
+        object.__setattr__(self, name, value)
+            
     def string(self):
         return self.__class__.__name__ + " num_samples={}\n".format(len(self)) + "└ of " + self.dataset.string().replace("\n", "\n  ")
 


### PR DESCRIPTION
This is based on https://github.com/mlmed/torchxrayvision/pull/75 

The idea is that setting transforms on merge or subset objects should raise an error because they don't work. If they were to work they would have side effects in the referenced datasets which could cause more serious consistency issues with reuse of those objects for things like evaluation.