### PR TITLE
Warn when possibly using the wrong normalization

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,6 +95,11 @@ def test_normalization_check():
         for ra in incorrect_ranges:
             test_x = torch.zeros([1,1,224,224])
             test_x.uniform_(ra[0], ra[1])
+            
+            # Sometimes uniform_ doesn't hit the edge cases we want
+            # so here the first 2 pixels are set to the limits
+            test_x[0][0][0] = ra[0]  
+            test_x[0][0][1] = ra[1]
             xrv.models.warning_log = {}
             model(test_x)
             assert xrv.models.warning_log['norm_correct'] == False, ra

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,6 +84,7 @@ def test_normalization_check():
         [0, 1],
         [-1, 1],
         [0, 1024],
+        [-1026, 1024],
     ]
     correct_ranges = [
         [-1024, 1024],
@@ -96,12 +97,12 @@ def test_normalization_check():
             test_x.uniform_(ra[0], ra[1])
             xrv.models.warning_log = {}
             model(test_x)
-            assert xrv.models.warning_log['norm_correct'] == False
+            assert xrv.models.warning_log['norm_correct'] == False, ra
             
         for ra in correct_ranges:
             test_x = torch.zeros([1,1,224,224])
             test_x.uniform_(ra[0], ra[1])
             xrv.models.warning_log = {}
             model(test_x)
-            assert xrv.models.warning_log['norm_correct'] == True
+            assert xrv.models.warning_log['norm_correct'] == True, ra
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -75,3 +75,33 @@ def test_num_classes():
         # should raise error:
         xrv.models.DenseNet(weights="all", num_classes=4)
         
+def test_normalization_check():
+    
+    models = [xrv.models.DenseNet(weights="densenet121-res224-all"),
+             xrv.models.ResNet(weights="resnet50-res512-all")]
+    
+    incorrect_ranges = [
+        [0, 1],
+        [-1, 1],
+        [0, 1024],
+    ]
+    correct_ranges = [
+        [-1024, 1024],
+        [-724, 412],
+    ]
+    
+    for model in models:
+        for ra in incorrect_ranges:
+            test_x = torch.zeros([1,1,224,224])
+            test_x.uniform_(ra[0], ra[1])
+            xrv.models.warning_log = {}
+            model(test_x)
+            assert xrv.models.warning_log['norm_correct'] == False
+            
+        for ra in correct_ranges:
+            test_x = torch.zeros([1,1,224,224])
+            test_x.uniform_(ra[0], ra[1])
+            xrv.models.warning_log = {}
+            model(test_x)
+            assert xrv.models.warning_log['norm_correct'] == True
+

--- a/torchxrayvision/models.py
+++ b/torchxrayvision/models.py
@@ -350,7 +350,11 @@ def fix_resolution(x, resolution: int, model: nn.Module):
     return x
 
 def warn_normalization(x):
-    """Check normalization of input and warn if possibly wrong."""
+    """Check normalization of input and warn if possibly wrong. When 
+    processing an image that may likely not have the correct 
+    normalization we can issue a warning. But running min and max on 
+    every image/batch is costly so we only do it on the first image/batch.
+    """
     
     # Only run this check on the first image so we don't hurt performance.
     if not "norm_check" in warning_log:

--- a/torchxrayvision/models.py
+++ b/torchxrayvision/models.py
@@ -360,8 +360,8 @@ def warn_normalization(x):
     if not "norm_check" in warning_log:
         x_min = x.min()
         x_max = x.max()
-        if not torch.logical_and(x_min < -255, x_max > 255):
-            print(f'Warning: Input image does not appear to normalized correctly. The input image has the range [{x_min:.2f},{x_max:.2f}] which doesn\'t seem to be in the [-1024,1024] range. This warning may be wrong though. Only the first image is tested and we are only use a heurstic in an attempt to save a user from using the wrong normalization.')
+        if torch.logical_or(-255 < x_min, x_max < 255) or torch.logical_or(x_min < -1024, 1024 < x_max):
+            print(f'Warning: Input image does not appear to be normalized correctly. The input image has the range [{x_min:.2f},{x_max:.2f}] which doesn\'t seem to be in the [-1024,1024] range. This warning may be wrong though. Only the first image is tested and we are only using a heuristic in an attempt to save a user from using the wrong normalization.')
             warning_log["norm_correct"] = False
         else:
             warning_log["norm_correct"] = True


### PR DESCRIPTION
This PR is in response to https://github.com/mlmed/torchxrayvision/issues/89 

When processing an image that may likely not have the correct normalization we can issue a warning. But running min and max on every image/batch is costly so we only do it on the first image/batch.