### PR TITLE
  Add test to verify 'Lesion' label is unified to 'Lung Lesion'

### DIFF
--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -195,3 +195,9 @@ def test_errors_when_doing_things_that_should_not_work():
     with pytest.raises(NotImplementedError) as excinfo:
         merged_dataset.pathologies = None
     
+def test_lesion_label_unified():
+    """Ensure 'Lung Lesion' is used instead of raw 'Lesion' in default_pathologies"""
+    assert "Lesion" not in xrv.datasets.default_pathologies, \
+        "Raw 'Lesion' found in default_pathologies. Use 'Lung Lesion' for consistency."
+    assert "Lung Lesion" in xrv.datasets.default_pathologies, \
+        "'Lung Lesion' missing from default_pathologies."


### PR DESCRIPTION
Closes #69

   The issue noted that VinBrain uses "Lesion" while MIMIC uses "Lung Lesion" for the same pathology.

   After investigating the codebase, the unification is already handled in datasets.py via np.char.replace on line 1358, and default_pathologies correctly uses "Lung Lesion".

   This PR adds a regression test to test_dataloaders.py to ensure this consistency is maintained going forward.